### PR TITLE
Clojure 1.11 upgrade

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/lacinia "0.35.1-SNAPSHOT"
+(defproject nubank/lacinia "0.35.2-SNAPSHOT"
   :description "A GraphQL server implementation in Clojure"
   :url "Fork of com.walmartlabs/lacinia."
   :license {:name "Apache, Version 2.0"
@@ -7,7 +7,7 @@
             [test2junit "1.2.5"]
             [s3-wagon-private "1.3.1"]]
   :deploy-repositories [["releases" {:url "s3p://nu-maven/releases/" :no-auth true}]]
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.11.0"]
                  [clj-antlr "0.2.5"]
                  [org.clojure/data.json "0.2.6"]]
   :source-paths ["src"

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -20,7 +20,7 @@
   Compiling the schema performs a number of validations and reorganizations to
   make query execution faster and simpler, such as generating a flatter structure for the
   schema, and pre-computing many defaults."
-  (:refer-clojure :exclude [compile])
+  (:refer-clojure :exclude [compile clojure])
   (:require
     [clojure.spec.alpha :as s]
     [com.walmartlabs.lacinia.introspection :as introspection]


### PR DESCRIPTION
## Changelog:
- Using clojure 1.11 and excluding clojure to avoid conflict with sachem